### PR TITLE
Fixed an issue with /api/plants/user.

### DIFF
--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 export const getPlants = function (user_id) {
-  return axios.get("/api/plants/" + user_id);
+  return axios.get("/api/plants/user/" + user_id);
 };
 // Gets a specific plant with the given id
 export const getPlant = function (id) {


### PR DESCRIPTION
I was verifying that the function getPlants indeed returned data and found that it wasn't.  I determined that the route was looking for api/plants/user to pull the list of plants a user has stored, but only /api/plants was in utils/API.