### PR TITLE
added checkbox to browse page

### DIFF
--- a/client/src/components/Accordion/index.js
+++ b/client/src/components/Accordion/index.js
@@ -7,7 +7,8 @@ import Typography from "@material-ui/core/Typography";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import TableCell from "@material-ui/core/TableCell";
 import TableRow from "@material-ui/core/TableRow";
-import './style.css'
+import "./style.css";
+import CheckboxLabels from "../Checkbox";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -24,7 +25,6 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-
 export default function ControlledExpansionPanels({ row }) {
   const classes = useStyles();
   const [expanded, setExpanded] = React.useState(false);
@@ -40,9 +40,16 @@ export default function ControlledExpansionPanels({ row }) {
           aria-controls="panel1bh-content"
           id="panel1bh-header"
         >
+          <CheckboxLabels />
           <TableRow key={row.name}>
-            <TableCell align="right"><img src={row.image_url} style={{width: "12vh"}}/></TableCell>
-            <TableCell component="th" scope="row" style={{fontWeight: 'bold'}}>
+            <TableCell align="right">
+              <img src={row.image_url} style={{ width: "12vh" }} />
+            </TableCell>
+            <TableCell
+              component="th"
+              scope="row"
+              style={{ fontWeight: "bold" }}
+            >
               {row.common_name}
             </TableCell>
             {/* <TableCell align="right">{row.family_name} </TableCell> */}
@@ -54,12 +61,26 @@ export default function ControlledExpansionPanels({ row }) {
         <ExpansionPanelDetails>
           <Typography>
             {console.log(row)}
-            <p><span style={{fontWeight: "bold"}}> Plant Care: </span>{row.plant_care}</p>
-            <p><span style={{fontWeight: "bold"}}>USDA Hardiness Zone: </span>{row.USDA_zone}</p>
-            <p><span style={{fontWeight: "bold"}}>Human Edible: </span> {row.human_edible}</p>
-            <p><span style={{fontWeight: "bold"}}>Pet Edible: </span>{row.pet_edible}</p>
-            <p><span style={{fontWeight: "bold"}}>Soil Needs: </span>{row.soil_needs}</p>
-            
+            <p>
+              <span style={{ fontWeight: "bold" }}> Plant Care: </span>
+              {row.plant_care}
+            </p>
+            <p>
+              <span style={{ fontWeight: "bold" }}>USDA Hardiness Zone: </span>
+              {row.USDA_zone}
+            </p>
+            <p>
+              <span style={{ fontWeight: "bold" }}>Human Edible: </span>{" "}
+              {row.human_edible}
+            </p>
+            <p>
+              <span style={{ fontWeight: "bold" }}>Pet Edible: </span>
+              {row.pet_edible}
+            </p>
+            <p>
+              <span style={{ fontWeight: "bold" }}>Soil Needs: </span>
+              {row.soil_needs}
+            </p>
           </Typography>
         </ExpansionPanelDetails>
       </ExpansionPanel>

--- a/client/src/components/Checkbox/index.js
+++ b/client/src/components/Checkbox/index.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { withStyles } from "@material-ui/core/styles";
+import { green } from "@material-ui/core/colors";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Checkbox from "@material-ui/core/Checkbox";
+import Favorite from "@material-ui/icons/Favorite";
+import FavoriteBorder from "@material-ui/icons/FavoriteBorder";
+
+const GreenCheckbox = withStyles({
+  root: {
+    color: green[400],
+    "&$checked": {
+      color: green[600],
+    },
+  },
+  checked: {},
+})((props) => <Checkbox color="root" {...props} />);
+
+export default function CheckboxLabels() {
+  const [state, setState] = React.useState({
+    checkedH: false,
+  });
+
+  const handleChange = (event) => {
+    setState({ ...state, [event.target.name]: event.target.checked });
+  };
+
+  return (
+    <FormControlLabel
+      control={
+        <GreenCheckbox
+          checked={state.checkedH}
+          onChange={handleChange}
+          icon={<FavoriteBorder />}
+          checkedIcon={<Favorite />}
+          name="checkedH"
+        />
+      }
+      label="Add to My Plantkins"
+    />
+  );
+}


### PR DESCRIPTION
new SUPER CUTE heart which acts as a checkbox and fills in w/ green component. Rendered on the browse page. So now if checked, needs to move the searched plant to the user's "my plantkins page", as well as appear on the card.